### PR TITLE
remove unecessary client_secret from oauth call

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -45,5 +45,4 @@ jobs:
             --numprocesses=auto \
             --dist=loadfile \
             --cov=core \
-            --aiohttp-fast \
             tests

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -36,6 +36,10 @@ jobs:
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=12 --max-line-length=127 --statistics --ignore E722,E501
 
+      - name: Create directories
+        run: |
+          mkdir data
+
       - name: Test with pytest
         run: |
           pytest \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
+## [0.5.1] - 2022-07-07
+### Removed
+- unused client_secret from oauth calls
+
+
 ## [0.5.0] - 2022-07-07
 ### Added
 - generate random client credentials to fallback configuration
 
 ### Changed
 - renamed configuration file to `core_configuration.json`
+
 
 ## [0.4.0] - 2021-12-11
 ### Added
@@ -38,6 +44,7 @@
 - dynamic addon loading with dedicated setup step
 - async file logging
 
+[0.5.1]: https://github.com/photos-network/core/compare/Release/v0.5.0...Release/v0.5.1
 [0.5.0]: https://github.com/photos-network/core/compare/Release/v0.4.0...Release/v0.5.0
 [0.4.0]: https://github.com/photos-network/core/compare/Release/v0.3.0...Release/v0.4.0
 [0.3.0]: https://github.com/photos-network/core/compare/Release/v0.2.1...Release/v0.3.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.10
 LABEL "description"="Photos.network core system"
-LABEL "version"="0.5.0"
+LABEL "version"="0.5.1"
 LABEL "maintainer"="github.com/photos-network"
 
 WORKDIR /app

--- a/core/authorization/__init__.py
+++ b/core/authorization/__init__.py
@@ -238,6 +238,6 @@ class Authorization:
 
     async def check_scope(self, scope: str):
         # TODO: check if requested scope has been granted by the user when creating the current token
-        _LOGGER.warning(f"check_scope({scope})")
+        _LOGGER.warning(f"check_scope({scope}) is not implemented yer!")
 
         # raise web.HTTPUnauthorized()

--- a/core/const.py
+++ b/core/const.py
@@ -1,7 +1,7 @@
 """Constants used by Photos.network core."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 5
-PATCH_VERSION = 0
+PATCH_VERSION = 1
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER = (3, 7, 1)

--- a/core/webserver/__init__.py
+++ b/core/webserver/__init__.py
@@ -38,9 +38,9 @@ class Webserver:
             self.app, loader=jinja2.FileSystemLoader("core/webserver/templates")
         )
 
+        self.app.middlewares.append(self.headers_middleware)
         self.app.middlewares.append(self.ban_middleware)
         self.app.middlewares.append(self.auth_middleware)
-        self.app.middlewares.append(self.headers_middleware)
 
     def register_request(self, view):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-async_timeout>=3.0.1,<4.0
+async_timeout>=4.0.1,<5.0
 aiohttp>=3.7.0,<4.0
 aiohttp_cors>=0.7.0
 aiohttp-jinja2>=1.4.2


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
client_secret is only used for password authentication and can be safely removed from token calls in oauth.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
